### PR TITLE
Update RawDKANEntityContext.php

### DIFF
--- a/src/Drupal/DKANExtension/Context/RawDKANEntityContext.php
+++ b/src/Drupal/DKANExtension/Context/RawDKANEntityContext.php
@@ -321,8 +321,11 @@ class RawDKANEntityContext extends RawDKANContext {
    * @return EntityDrupalWrapper $wrapper - EntityMetadataWrapper
    */
   public function save($fields) {
+    $user = $this->getCurrentUser();
+    $GLOBALS['user'] = $user;
     $wrapper = $this->new_wrapper();
     $this->pre_save($wrapper, $fields);
+    $wrapper->revision->set(1);
     $wrapper->save();
     $this->post_save($wrapper, $fields);
     return $wrapper;


### PR DESCRIPTION
Global user variable is set to anonymous within hook_node_update. Workbench moderation isn't working properly during tests because this issue.

There is also another issue related with the revision flag which is not being set in nodes created using the dkan extension. However, creating them from UI works fine ($node->revision is properly set to 1).

@frankcarey Do you think there is a better way to handle this?
