### PR TITLE
Add support to file resup file uploads

### DIFF
--- a/src/Drupal/DKANExtension/Context/DKANContext.php
+++ b/src/Drupal/DKANExtension/Context/DKANContext.php
@@ -490,11 +490,6 @@ class DKANContext extends RawDKANContext {
   public function iAttachTheDrupalFileTo($path, $field)
   {
     $field = $this->fixStepArgument($field);
-
-    // Relative paths stopped working after selenium 2.44.
-    $offset = 'features/bootstrap/FeatureContext.php';
-    $dir =  __file__;
-    $test_dir = str_replace($offset, "", $dir);
     $path = $this->getMinkParameter('files_path') . '/' . $path;
     $this->getSession()->getPage()->attachFileToField($field, $path);
   }
@@ -509,11 +504,6 @@ class DKANContext extends RawDKANContext {
     $page = $session->getPage();
     $session->executeScript('jQuery(".file-resup-wrapper input").show()');
     $session->executeScript('jQuery(".file-resup-wrapper input[name=\'' . $field . '\']").parent().find("input[type=\'file\']").attr("id", "' . $field . '")');
-
-    // Relative paths stopped working after selenium 2.44.
-    $offset = 'features/bootstrap/FeatureContext.php';
-    $dir =  __file__;
-    $test_dir = str_replace($offset, "", $dir);
     $path = $this->getMinkParameter('files_path') . '/' . $path;
     $session->getPage()->attachFileToField($field, $path);
   }

--- a/src/Drupal/DKANExtension/Context/DKANContext.php
+++ b/src/Drupal/DKANExtension/Context/DKANContext.php
@@ -490,7 +490,7 @@ class DKANContext extends RawDKANContext {
   public function iAttachTheDrupalFileTo($path, $field)
   {
     $field = $this->fixStepArgument($field);
-    $path =  $this->getFile($path);
+    $path = $this->getMinkParameter('files_path') . '/' . $path;
     $this->getSession()->getPage()->attachFileToField($field, $path);
   }
 
@@ -499,7 +499,7 @@ class DKANContext extends RawDKANContext {
    */
   public function iAttachTheDrupalFileUsingFileResup($path, $field)
   {
-    $path = $this->getFile($path);
+    $path = $this->getMinkParameter('files_path') . '/' . $path;
     $field = $this->fixStepArgument($field);
     $session = $this->getSession();
     $page = $session->getPage();

--- a/src/Drupal/DKANExtension/Context/DKANContext.php
+++ b/src/Drupal/DKANExtension/Context/DKANContext.php
@@ -500,6 +500,37 @@ class DKANContext extends RawDKANContext {
   }
 
   /**
+   * @When I attach the file :path to :field using file resup
+   */
+  public function iAttachTheDrupalFileUsingFileResup($path, $field)
+  {
+    $field = $this->fixStepArgument($field);
+    $session = $this->getSession();
+    $page = $session->getPage();
+    $session->executeScript('jQuery(".file-resup-wrapper input").show()');
+    $session->executeScript('jQuery(".file-resup-wrapper input[name=\'' . $field . '\']").parent().find("input[type=\'file\']").attr("id", "' . $field . '")');
+
+    // Relative paths stopped working after selenium 2.44.
+    $offset = 'features/bootstrap/FeatureContext.php';
+    $dir =  __file__;
+    $test_dir = str_replace($offset, "", $dir);
+    $path = $this->getMinkParameter('files_path') . '/' . $path;
+    $session->getPage()->attachFileToField($field, $path);
+  }
+
+  /**
+   * Wait for upload file to finish
+   *
+   * Wait until the class="progress-bar" element is gone,
+   * or timeout after 30 seconds (30,000 ms).
+   *
+   * @Given /^I wait for the file upload to finish$/
+   */
+  public function iWaitForUploadFileToFinish() {
+    $this->getSession()->wait(30000, 'jQuery(".progress-bar").length === 0');
+  }
+
+  /**
    * @Then I should see the list of permissions for :role role
    */
   public function iShouldSeePermissionsForRole($role)

--- a/src/Drupal/DKANExtension/Context/DKANContext.php
+++ b/src/Drupal/DKANExtension/Context/DKANContext.php
@@ -490,7 +490,7 @@ class DKANContext extends RawDKANContext {
   public function iAttachTheDrupalFileTo($path, $field)
   {
     $field = $this->fixStepArgument($field);
-    $path = $this->getMinkParameter('files_path') . '/' . $path;
+    $path =  $this->getFile($path);
     $this->getSession()->getPage()->attachFileToField($field, $path);
   }
 
@@ -499,12 +499,12 @@ class DKANContext extends RawDKANContext {
    */
   public function iAttachTheDrupalFileUsingFileResup($path, $field)
   {
+    $path = $this->getFile($path);
     $field = $this->fixStepArgument($field);
     $session = $this->getSession();
     $page = $session->getPage();
     $session->executeScript('jQuery(".file-resup-wrapper input").show()');
     $session->executeScript('jQuery(".file-resup-wrapper input[name=\'' . $field . '\']").parent().find("input[type=\'file\']").attr("id", "' . $field . '")');
-    $path = $this->getMinkParameter('files_path') . '/' . $path;
     $session->getPage()->attachFileToField($field, $path);
   }
 

--- a/src/Drupal/DKANExtension/Context/RawDKANContext.php
+++ b/src/Drupal/DKANExtension/Context/RawDKANContext.php
@@ -218,35 +218,4 @@ class RawDKANContext extends RawDrupalContext implements DKANAwareInterface {
     }
   }
 
-
-  public function isRemoteFile($file) {
-    return filter_var($file, FILTER_VALIDATE_URL);
-  }
-
-  public function assertRemoteFileExists($file) {
-    $ch = curl_init($file);
-    curl_setopt($ch, CURLOPT_NOBODY, true);
-    curl_exec($ch);
-    $retcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-    curl_close($ch);
-
-    if ($retcode !== 200) {
-      throw new \Exception("Remote file {$file} doesn't exists");
-    }
-  }
-
-  public function getFile($file) {
-    if($this->isRemoteFile($file)) {
-      $this->assertRemoteFileExists($file);
-      $temp = tempnam('', 'WebDriverZip');
-      file_put_contents($temp, file_get_contents($file));
-      $file = $temp;
-    }
-
-    if (empty($file)) {
-      throw new Exception('Path could not be empty');
-    }
-    return $file;
-  }
-
 }


### PR DESCRIPTION
This adds two steps: the first one to attach files to file resup widgets. The second one to wait until the file upload is complete.
