### PR TITLE
civic-1474 Fix test for adding dataset to a group

### DIFF
--- a/src/Drupal/DKANExtension/Context/DKANContext.php
+++ b/src/Drupal/DKANExtension/Context/DKANContext.php
@@ -319,7 +319,8 @@ class DKANContext extends RawDKANContext {
     $field = $this->fixStepArgument($field);
     $value = $this->fixStepArgument($value);
     // Focus means autocoplete will actually show up.
-    $this->getSession()->getDriver()->focus('//input[@value="' . $field . '"]');
+    $xpath = '//div[@id="'. $field . '"]//input';
+    $this->getSession()->getDriver()->focus($xpath);
     //$page->fillField($field, $value);
     $this->iWaitForSeconds(1);
     // Selects the first dropdown since there is no id or other way to


### PR DESCRIPTION
![screenshot_3_14_16__4_20_pm](https://cloud.githubusercontent.com/assets/314172/13760331/a63fe92c-ea00-11e5-9470-e7a83a6fc21b.png)

Adding the topics field to the dataset form broke the test for adding a dataset to a group because the test was looking for a chosen field with 'choose some options', and it was looking in the topics field for the group name and that fails.

The test now looks for the field based on div ID and then the input field.

![screenshot_3_11_16__3_15_pm](https://cloud.githubusercontent.com/assets/314172/13760391/f14ad788-ea00-11e5-9d0b-3655e323ac40.png)
