### PR TITLE
Fix hhs search hanging.

### DIFF
--- a/src/Drupal/DKANExtension/Context/SearchAPIContext.php
+++ b/src/Drupal/DKANExtension/Context/SearchAPIContext.php
@@ -50,7 +50,7 @@ class SearchAPIContext extends RawDrupalContext implements SnippetAcceptingConte
     }
 
     foreach ($indexes as $index) {
-      $items = search_api_get_items_to_index($this->search_indexes[$index]);
+      $items = search_api_get_items_to_index($this->search_indexes[$index], 10);
       search_api_index_specific_items($this->search_indexes[$index], $items);
     }
   }


### PR DESCRIPTION
Ref civic-1899

The reason these tests hang is that over 2000 nodes need to get indexed in HHS
when the indexed gets rebuilt.

By limiting the number of nodes that need to get indexed we can effectively
avoid this issue for any sites that has a large number of nodes to index.

Another solution would be (perhaps in combination) to reduce the number of
nodes in the site QA dbs via the sanitization steps.
# Acceptance
- [x] A site with many nodes that reverts the default indexes does not hang on tests.
- [x] Dkan tests still pass with this indexing limitation in place.
