### PR TITLE
Remove url hash from url asserts

### DIFF
--- a/src/Drupal/DKANExtension/Context/RawDKANContext.php
+++ b/src/Drupal/DKANExtension/Context/RawDKANContext.php
@@ -141,6 +141,12 @@ class RawDKANContext extends RawDrupalContext implements DKANAwareInterface {
     $current_url = $session->getCurrentUrl();
     // Support relative paths when on a "base_url" page. Otherwise assume a full url.
     $current_url = str_replace($this->getMinkParameter("base_url"), "", $current_url);
+
+    // Remove hash part from url since it's widely used
+    // for client side routing and this can make some
+    // test fail.
+    $current_url = strtok($current_url, "#");
+
     // This code was setup to ignore url get params, but we are using them for datasets, so ignore this for now.
     //$current_url = drupal_parse_url($current_url);
     //$current_url = $current_url['path'];


### PR DESCRIPTION
Remove hash part from url since it's widely used
for client side routing and this can make some
test fail.
## Acceptance criteria
- Dkan tests should pass
