### PR TITLE
Fixed issue of node status (published) not being saved.

### DIFF
--- a/src/Drupal/DKANExtension/Context/RawDKANEntityContext.php
+++ b/src/Drupal/DKANExtension/Context/RawDKANEntityContext.php
@@ -289,7 +289,8 @@ class RawDKANEntityContext extends RawDKANContext {
         case 'field_item_image':
           // Links
         case 'field_item_link':
-          // Text field formatting?
+          $wrapper->$property->set(array("url" => $value));
+          break;
         case 'token':
           // References to nodes
         default:

--- a/src/Drupal/DKANExtension/Context/WorkflowContext.php
+++ b/src/Drupal/DKANExtension/Context/WorkflowContext.php
@@ -64,7 +64,12 @@ class WorkflowContext extends RawDKANContext {
 
       // This function actually updates the transition.
       workbench_moderation_moderate($node, $state_key, $current_user->uid);
-
+      $callbacks = &drupal_register_shutdown_function();
+      while (list($key, $callback) = each($callbacks)) {
+        if ($callback['callback'] == "workbench_moderation_store") {
+          call_user_func_array($callback['callback'], $callback['arguments']);
+        }
+      }
       // Back global user to the original user. Probably an anonymous.
       $user = $global_user;
     }


### PR DESCRIPTION
Ref https://github.com/NuCivic/usda-nal/issues/858
### Description
#### Support Link fields for node import

Added code to _set_field_ function in _RawDKANEntityContext.php_ to handle setting fields of type _field_item_link_.

To reproduce the issue and test the fix following is an example scenario. Adding the fix makes this scenario work.

```
@api @disablecaptcha @javascript
Feature:
  Test Feature for the Link field support.

  @ok
  Scenario: I want to add a dataset with related content.
    And datasets:
      | title        | published | related content |
      | Test Dataset | No        | example.com    |
```

Running the test scenario with the master branch should yell the `Not sure how to handle field 'related content' with type 'list<field_item_link>' (Exception)` error.
#### Workflow "Published" status is not applied

Node status remains unpublished after changing the moderation state to published using the steps provided by the `WorkflowContext`.

After investigations. Turns out that the workbench_moderation_moderate defer some status updates on the node (currently the "Publish" status) to the process shutdown. Which does not work well on Behat since scenarios are run on a single drupal bootstrap. To work around this setup. After calling the `workbench_moderation_moderate` callback we check if a call to the `workbench_moderation_store` function is part of the shutdown execution and run it.

To reproduce the issue and test the fix following is an example scenario. Adding the fix makes this scenario work.

```
@api @disablecaptcha @javascript
Feature:
  Test Feature for the Published content access issue.

  @ok
  Scenario: As an Anonymous user I should be able to access published content.
    Given I am an anonymous user
    Given users:
      | name       | roles                       | mail                 |
      | supervisor | Workflow Supervisor, editor | supervisor@email.com |
    And datasets:
      | title         | published |
      | Test Dataset  | No        |
    And resources:
      | title         | dataset      | format | published |
      | Test Resource | Test Dataset | csv    | no        |
    When "supervisor" updates the moderation state of "Test Dataset" to "Published"
    Then I should be able to access the "Test Dataset" page
```

Running the test scenario with the master branch should yell the `Current page is /user/login?destination=node/30, but /dataset/test-dataset-0 expected. (Exception)` error.
