### PR TITLE
Add support for 'safeword_field' type fields

### DIFF
--- a/src/Drupal/DKANExtension/Context/RawDKANEntityContext.php
+++ b/src/Drupal/DKANExtension/Context/RawDKANEntityContext.php
@@ -292,6 +292,9 @@ class RawDKANEntityContext extends RawDKANContext {
           // Text field formatting?
         case 'token':
           // References to nodes
+        case 'safeword_field':
+          $wrapper->$property->set(array("machine" => $value));
+          break;
         default:
           // For now, just error out as we can't handle it yet.
           throw new \Exception("Not sure how to handle field '$label' with type '$field_type'");


### PR DESCRIPTION
Related ticket: https://jira.govdelivery.com/browse/CIVIC-2837
### Description

Support 'safeword_field' provided by the [safeword](https://www.drupal.org/project/safeword) module. We use this on the harvest_source node type to provide the machine name we can use for migration and cache folders names.
