### PR TITLE
Make beforecreate hooks static functions

### DIFF
--- a/src/Drupal/DKANExtension/Context/WorkflowContext.php
+++ b/src/Drupal/DKANExtension/Context/WorkflowContext.php
@@ -172,7 +172,7 @@ class WorkflowContext extends RawDKANContext {
   /**
    * @beforeDKANEntityCreate
    */
-  public function setGlobalUserBeforeEntity(\Drupal\DKANExtension\Hook\Scope\BeforeDKANEntityCreateScope $scope) {
+  public static function setGlobalUserBeforeEntity(\Drupal\DKANExtension\Hook\Scope\BeforeDKANEntityCreateScope $scope) {
     // Don't do anything if workbench isn't enabled or this isn't a node.
     $wrapper = $scope->getEntity();
     if (!function_exists('workbench_moderation_moderate_node_types') || $wrapper->type() !== 'node'){
@@ -192,7 +192,7 @@ class WorkflowContext extends RawDKANContext {
       // Then set the global user so that stupid workbench is happy.
       global $user;
       // Save a backup of the user (should be anonymous)
-      $this->old_global_user = $user;
+      self::$old_global_user = $user;
       $user = $wrapper->author->value();
     }
   }
@@ -200,11 +200,11 @@ class WorkflowContext extends RawDKANContext {
   /**
    * @afterDKANEntityCreate
    */
-  public function removeGlobalUserAfterEntity(\Drupal\DKANExtension\Hook\Scope\AfterDKANEntityCreateScope $scope) {
+  public static function removeGlobalUserAfterEntity(\Drupal\DKANExtension\Hook\Scope\AfterDKANEntityCreateScope $scope) {
     // After we've created the entity, set it back the the old global user (anon) so it doesn't pollute other things.
-    if (isset($this->old_global_user)) {
+    if (isset(self::$old_global_user)) {
       global $user;
-      $user = $this->old_global_user;
+      $user = self::$old_global_user;
     }
   }
 }


### PR DESCRIPTION
On the last update of the dkanextention, the corresponding behat upgrade broke a number of tests due to errors about the hook functions being called non-statically. Ultimately we rolled back the behat version and this PR, but I'm resubmitting for reference when we ultimately do update behat.

I'm not completely convinced that this is the fix that's necessary. The hooks in questions seem to be step hooks, and according to the behat documentation should **not** be static. So the problem may lie in something about the scope definition, not the hook functions themselves.
