### PR TITLE
Add click exact text method.

### DIFF
--- a/src/Drupal/DKANExtension/Context/DKANContext.php
+++ b/src/Drupal/DKANExtension/Context/DKANContext.php
@@ -405,6 +405,25 @@ class DKANContext extends RawDKANContext {
   }
 
   /**
+   * Click some exact text.
+   *
+   * @When I click on the exact text :text
+   */
+
+  public function iClickOnTheExactText($text) {
+    $session = $this->getSession();
+    $element = $session->getPage()->find(
+      'xpath',
+      $session->getSelectorsHandler()->selectorToXpath('xpath',
+        '//*[text() = "' . $text . '"]')
+    );
+    if (NULL === $element) {
+      throw new \InvalidArgumentException(sprintf('Cannot find text: "%s"', $text));
+    }
+    $element->click();
+  }
+
+  /**
    * Click on map icon as identified by its z-index.
    *
    * @Given /^I click map icon number "([^"]*)"$/


### PR DESCRIPTION
REF CIVIC-3950

Add the context.
@When I click on the exact :text

Which differs from a similar context in that the supplied text must be an exact
match.
# AC
- [x] @When I click on the exact :text, is an available and working context.
