### PR TITLE
Make sure dkan_worflow is enabled for tests.

### DIFF
--- a/src/Drupal/DKANExtension/Context/WorkflowContext.php
+++ b/src/Drupal/DKANExtension/Context/WorkflowContext.php
@@ -174,6 +174,9 @@ class WorkflowContext extends RawDKANContext {
    * @beforeDKANEntityCreateScope
    */
   public function setGlobalUserBeforeEntity(BeforeDKANEntityCreateScope $scope) {
+    // Enable workflow in case it has not been enabled.
+    module_enable('dkan_workflow');
+
     // Don't do anything if workbench isn't enabled or this isn't a node.
     $wrapper = $scope->getEntity();
     if (!function_exists('workbench_moderation_moderate_node_types') || $wrapper->type() !== 'node'){


### PR DESCRIPTION
REF CIVIC-3522
# Description

dkan_workflow is not currently enabled in dkan, thus we need to enable the
module in order to run dkan_workflow feature tests.  This commit enables
dkan_workflow before a scenario is run.
# QA Steps
- [ ] checkout nucivic/dkan:civic-3522
- [ ] cd `dkan/tests` && composer install
- [ ] cd vendor/nucivic/dkanextension
- [ ] git fetch origin civic-3522-fix-workflow-context-dkan
- [ ] git checkout civic-3522-fix-workflow-context-dkan
- [ ] verify `ahoy dkan test features/hhs.workbench.feature --name='As <user>, I <visibility> be able to access My workbench'` runs.
