### PR TITLE
Enable dkan_workflow for dkan tests.

### DIFF
--- a/src/Drupal/DKANExtension/Context/WorkflowContext.php
+++ b/src/Drupal/DKANExtension/Context/WorkflowContext.php
@@ -15,15 +15,6 @@ class WorkflowContext extends RawDKANContext {
   /**
    * @BeforeScenario
    */
-  public function gatherContexts(BeforeScenarioScope $scope){
-    parent::gatherContexts($scope);
-    $environment = $scope->getEnvironment();
-    $this->pageContext = $environment->getContext('Drupal\DKANExtension\Context\PageContext');
-  }
-
-  /**
-   * @BeforeScenario
-   */
   public function addDKAN_Workflow(BeforeScenarioScope $event)
   {
     // Enable 'open_data_federal_extras' module.

--- a/src/Drupal/DKANExtension/Context/WorkflowContext.php
+++ b/src/Drupal/DKANExtension/Context/WorkflowContext.php
@@ -1,5 +1,6 @@
 <?php
 namespace Drupal\DKANExtension\Context;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Drupal\DKANExtension\Hook\Scope\BeforeDKANEntityCreateScope;
 
 use \stdClass;
@@ -10,6 +11,24 @@ use \stdClass;
 class WorkflowContext extends RawDKANContext {
 
   protected $old_global_user;
+
+  /**
+   * @BeforeScenario
+   */
+  public function gatherContexts(BeforeScenarioScope $scope){
+    parent::gatherContexts($scope);
+    $environment = $scope->getEnvironment();
+    $this->pageContext = $environment->getContext('Drupal\DKANExtension\Context\PageContext');
+  }
+
+  /**
+   * @BeforeScenario
+   */
+  public function addDKAN_Workflow(BeforeScenarioScope $event)
+  {
+    // Enable 'open_data_federal_extras' module.
+    module_enable(array('dkan_workflow', 'dkan_workflow_permissions'));
+  }
 
   /**
    * @Given I update the moderation state of :named_entity to :state
@@ -174,9 +193,6 @@ class WorkflowContext extends RawDKANContext {
    * @beforeDKANEntityCreateScope
    */
   public function setGlobalUserBeforeEntity(BeforeDKANEntityCreateScope $scope) {
-    // Enable workflow in case it has not been enabled.
-    module_enable('dkan_workflow');
-
     // Don't do anything if workbench isn't enabled or this isn't a node.
     $wrapper = $scope->getEntity();
     if (!function_exists('workbench_moderation_moderate_node_types') || $wrapper->type() !== 'node'){


### PR DESCRIPTION
REF CIVIC-3522
# Description

dkan_workflow is not currently enabled in dkan, thus we need to enable the
module in order to run dkan_workflow feature tests. This commit enables
dkan_workflow before a scenario is run.
# QA Steps
- [ ] checkout nucivic/dkan:civic-3522
- [ ] cd dkan/tests && composer install
- [ ] cd vendor/nucivic/dkanextension
- [ ] git fetch origin civic-3522-fix-workflow-context-dkan
- [ ] git checkout civic-3522-fix-workflow-context-dkan
- [ ] verify ahoy dkan test features/hhs.workbench.feature --name='As <user>, I <visibility> be able to access My workbench' runs.
