### PR TITLE
Add @BeforeSuite and @AfterSuite

### DIFF
--- a/src/Drupal/DKANExtension/Context/RawDKANContext.php
+++ b/src/Drupal/DKANExtension/Context/RawDKANContext.php
@@ -17,6 +17,8 @@ use Behat\Behat\Tester\Exception\PendingException;
 use EntityFieldQuery;
 use \stdClass;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
+use Behat\Testwork\Hook\Scope\AfterSuiteScope;
 
 /**
  * Defines application features from the specific context.
@@ -53,6 +55,21 @@ class RawDKANContext extends RawDrupalContext implements DKANAwareInterface {
    * @var Session
    */
   protected $fakeSession;
+
+  /**
+   * @BeforeSuite
+   */
+  public static function disableAdminMenuCache(BeforeSuiteScope $scope) {
+    // Turn off cache so the menu lives in the html.
+    variable_set('admin_menu_cache_client', FALSE);
+  }
+
+  /**
+   * @AfterSuite
+   */
+  public static function enableAdminMenuCache(AfterSuiteScope $scope) {
+    variable_set('admin_menu_cache_client', TRUE);
+  }
 
   /**
    * @BeforeScenario @disablecaptcha


### PR DESCRIPTION
## Description

Admin menu tests fail because of a delay in the drop downs.
If we disable admin menu cache before running tests this will not happen.
