### PR TITLE
Modify step used to check if data.json is valid

### DIFF
--- a/src/Drupal/DKANExtension/Context/PODContext.php
+++ b/src/Drupal/DKANExtension/Context/PODContext.php
@@ -51,6 +51,28 @@ class PODContext extends RawDKANContext {
   }
 
   /**
+   * @When I should not see a valid data.json
+   */
+  public function iShouldNotSeeAValidDatasjon() {
+    // Change /data.json path to /json during tests. The '.' on the filename breaks tests on CircleCI's server.
+    $data_json = open_data_schema_map_api_load('data_json_1_1');
+    if ($data_json->endpoint !== 'json') {
+      $data_json->endpoint = 'json';
+      drupal_write_record('open_data_schema_map', $data_json, 'id');
+      drupal_static_reset('open_data_schema_map_api_load_all');
+      menu_rebuild();
+    }
+    // Get base URL.
+    $url = $this->getMinkParameter('base_url') ? $this->getMinkParameter('base_url') : "http://127.0.0.1::8888";
+
+    // Validate POD.
+    $results = open_data_schema_pod_process_validate($url . '/json', TRUE);
+    if (!$results['errors']) {
+      throw new \Exception(sprintf('Data.json is not valid.'));
+    }
+  }
+
+  /**
    * @Then I should see a valid catalog xml
    */
   public function iShouldSeeAValidCatalogXml() {

--- a/src/Drupal/DKANExtension/Context/PODContext.php
+++ b/src/Drupal/DKANExtension/Context/PODContext.php
@@ -28,10 +28,12 @@ class PODContext extends RawDKANContext {
     $environment = $scope->getEnvironment();
     $this->pageContext = $environment->getContext('Drupal\DKANExtension\Context\PageContext');
   }
+
   /**
-   * @When I should see a valid data.json
+   * @Then I :should see a valid data.json
    */
-  public function iShouldSeeAValidDatasjon() {
+  public function iSeeAValidDataJson($should)
+  {
     // Change /data.json path to /json during tests. The '.' on the filename breaks tests on CircleCI's server.
     $data_json = open_data_schema_map_api_load('data_json_1_1');
     if ($data_json->endpoint !== 'json') {
@@ -45,29 +47,11 @@ class PODContext extends RawDKANContext {
 
     // Validate POD.
     $results = open_data_schema_pod_process_validate($url . '/json', TRUE);
-    if ($results['errors']) {
+    if ($results['errors'] && $should === 'should') {
       throw new \Exception(sprintf('Data.json is not valid.'));
     }
-  }
 
-  /**
-   * @When I should not see a valid data.json
-   */
-  public function iShouldNotSeeAValidDatasjon() {
-    // Change /data.json path to /json during tests. The '.' on the filename breaks tests on CircleCI's server.
-    $data_json = open_data_schema_map_api_load('data_json_1_1');
-    if ($data_json->endpoint !== 'json') {
-      $data_json->endpoint = 'json';
-      drupal_write_record('open_data_schema_map', $data_json, 'id');
-      drupal_static_reset('open_data_schema_map_api_load_all');
-      menu_rebuild();
-    }
-    // Get base URL.
-    $url = $this->getMinkParameter('base_url') ? $this->getMinkParameter('base_url') : "http://127.0.0.1::8888";
-
-    // Validate POD.
-    $results = open_data_schema_pod_process_validate($url . '/json', TRUE);
-    if (!$results['errors']) {
+    if (!$results['errors'] && $should === 'should not') {
       throw new \Exception(sprintf('Data.json is valid.'));
     }
   }
@@ -139,7 +123,7 @@ class PODContext extends RawDKANContext {
     // Clean the array values and remove all non POD valid licenses if required.
     foreach ($licenses as $key => $value) {
       if (($option != 'all') && !isset($value['uri'])) {
-          unset($licenses[$key]);
+        unset($licenses[$key]);
       } else {
         $licenses[$key] = $value['label'];
       }

--- a/src/Drupal/DKANExtension/Context/PODContext.php
+++ b/src/Drupal/DKANExtension/Context/PODContext.php
@@ -68,7 +68,7 @@ class PODContext extends RawDKANContext {
     // Validate POD.
     $results = open_data_schema_pod_process_validate($url . '/json', TRUE);
     if (!$results['errors']) {
-      throw new \Exception(sprintf('Data.json is not valid.'));
+      throw new \Exception(sprintf('Data.json is valid.'));
     }
   }
 


### PR DESCRIPTION
The step used to check if the data.json is valid was modified to support both "should" and "should not" scenarios.

Ref: https://github.com/NuCivic/dkan/pull/1548